### PR TITLE
Add meta tags and @sveltejs/adapter-static to build a static webpage

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-auto": "^2.0.0",
+		"@sveltejs/adapter-static": "^2.0.3",
 		"@sveltejs/kit": "^1.20.4",
 		"@tailwindcss/typography": "^0.5.10",
 		"@types/aos": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@splinetool/runtime':
     specifier: ^0.9.490
@@ -28,6 +24,9 @@ devDependencies:
   '@sveltejs/adapter-auto':
     specifier: ^2.0.0
     version: 2.0.0(@sveltejs/kit@1.20.4)
+  '@sveltejs/adapter-static':
+    specifier: ^2.0.3
+    version: 2.0.3(@sveltejs/kit@1.20.4)
   '@sveltejs/kit':
     specifier: ^1.20.4
     version: 1.20.4(svelte@4.0.5)(vite@4.4.2)
@@ -480,6 +479,14 @@ packages:
     dependencies:
       '@sveltejs/kit': 1.20.4(svelte@4.0.5)(vite@4.4.2)
       import-meta-resolve: 2.2.2
+    dev: true
+
+  /@sveltejs/adapter-static@2.0.3(@sveltejs/kit@1.20.4):
+    resolution: {integrity: sha512-VUqTfXsxYGugCpMqQv1U0LIdbR3S5nBkMMDmpjGVJyM6Q2jHVMFtdWJCkeHMySc6mZxJ+0eZK3T7IgmUCDrcUQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^1.5.0
+    dependencies:
+      '@sveltejs/kit': 1.20.4(svelte@4.0.5)(vite@4.4.2)
     dev: true
 
   /@sveltejs/kit@1.20.4(svelte@4.0.5)(vite@4.4.2):
@@ -2954,3 +2961,7 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/app.html
+++ b/src/app.html
@@ -1,17 +1,39 @@
 <!DOCTYPE html>
 <html class="scroll-smooth" lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/comcamp-22nd-logo.png" />
-		<link
-			rel="stylesheet"
-			href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
-		/>
-		<meta name="viewport" content="width=device-width" />
-		%sveltekit.head%
-		<title>COMCAMP MJU</title>
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+
+<head>
+	<meta charset="utf-8" />
+	<link rel="icon" href="%sveltekit.assets%/comcamp-22nd-logo.png" />
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />
+	<meta name="viewport" content="width=device-width" />
+	<!-- Primary Meta Tags -->
+	<title>โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้</title>
+	<meta name="title" content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้" />
+	<meta name="description"
+		content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้ กลับมาแล้ว! กับกิจกรรมสุดมันส์และความรู้แน่นๆ ที่จะพาน้องๆ ไปเรียนรู้เกี่ยวกับเทคโนโลยีและนวัตกรรมใหม่ๆในปัจจุบัน" />
+
+	<!-- Open Graph / Facebook -->
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="https://comcamp.csmju.com/" />
+	<meta property="og:title" content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้" />
+	<meta property="og:description"
+		content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้ กลับมาแล้ว! กับกิจกรรมสุดมันส์และความรู้แน่นๆ ที่จะพาน้องๆ ไปเรียนรู้เกี่ยวกับเทคโนโลยีและนวัตกรรมใหม่ๆในปัจจุบัน" />
+	<meta property="og:image" content="https://i.imgur.com/qrdihfh.png" />
+
+	<!-- Twitter -->
+	<meta property="twitter:card" content="summary_large_image" />
+	<meta property="twitter:url" content="https://comcamp.csmju.com/" />
+	<meta property="twitter:title" content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้" />
+	<meta property="twitter:description"
+		content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้ กลับมาแล้ว! กับกิจกรรมสุดมันส์และความรู้แน่นๆ ที่จะพาน้องๆ ไปเรียนรู้เกี่ยวกับเทคโนโลยีและนวัตกรรมใหม่ๆในปัจจุบัน" />
+	<meta property="twitter:image" content="https://i.imgur.com/qrdihfh.png" />
+
+	%sveltekit.head%
+	<title>COMCAMP MJU</title>
+</head>
+
+<body data-sveltekit-preload-data="hover">
+	<div style="display: contents">%sveltekit.body%</div>
+</body>
+
 </html>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,1 +1,2 @@
 export const ssr = false;
+export const prerender = true;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/kit/vite';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -11,7 +11,15 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter({
+			// default options are shown. On some platforms
+			// these options are set automatically — see below
+			pages: 'build',
+			assets: 'build',
+			fallback: undefined,
+			precompress: false,
+			strict: true
+		})
 	}
 };
 


### PR DESCRIPTION
**This pull request adds the following changes to the project:**

1. Meta tags to the index.html file
2. The @sveltejs/adapter-static package to build a static webpage

**Here is a more detailed description of each change:**

Meta tags are used to provide information about a webpage to search engines and other web applications. I have added the following meta tags to index.html

```html
<meta name="title" content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้" />
<meta name="description" content="โครงการค่ายยุวชนคอมพิวเตอร์ครั้งที่ 22 มหาวิทยาลัยแม่โจ้ กลับมาแล้ว! กับกิจกรรมสุดมันส์และความรู้แน่นๆ ที่จะพาน้องๆ ไปเรียนรู้เกี่ยวกับเทคโนโลยีและนวัตกรรมใหม่ๆในปัจจุบัน" />
```

These meta tags will help search engines to better understand and index our webpage

Adding the `@sveltejs/adapter-static package`:

The @sveltejs/adapter-static package is a SvelteKit adapter that can be used to build static webpages. I have added this package to the project and configured it to `build` a static webpage in the build directory.