### PR TITLE
Fix misspelling in user dashboard

### DIFF
--- a/src/lib/dashboardData.ts
+++ b/src/lib/dashboardData.ts
@@ -13,7 +13,7 @@ const menu = [
 		icon: 'ion:receipt-outline'
 	},
 	{
-		title: 'ส่งหลักฐานขออณุญาตผู้ปกครอง',
+		title: 'ส่งหนังสือขออณุญาตผู้ปกครอง',
 		path: '/dashboard/parent-permission-submission',
 		icon: 'mdi:file-document-edit-outline'
 	},
@@ -44,12 +44,12 @@ const adminMenu = [
 
 const filesDownloader = [
 	{
-		title: 'ไฟล์ขออณุญาตผู้ปกครอง.',
+		title: 'หนังสือขออณุญาตผู้ปกครอง.',
 		src: parentPermissionFile,
 		icon: 'ph:image-light'
 	},
 	{
-		title: 'ไฟล์กำหนดการ',
+		title: 'กำหนดการ',
 		src: scheduleImageFile,
 		icon: 'dashicons:pdf'
 	}

--- a/src/routes/authentication/info-register/+page.svelte
+++ b/src/routes/authentication/info-register/+page.svelte
@@ -303,7 +303,7 @@
 									>
 										<option class="text-base-200" selected disabled>คำนำหน้า</option>
 										<option class="text-base-200" value="นาย">นาย</option>
-										<option class="text-base-200" value="นาง">นาง</option>
+										<option class="text-base-200" value="นางสาว">นางสาว</option>
 									</select>
 								</div>
 								<div class="flex-grow">

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -189,7 +189,7 @@
 						<div class="divider text-sm">อื่น ๆ</div>
 
 						<li class="dropdown dropdown-start">
-							<label>ดาวโหลดเอกสาร</label>
+							<label>ดาวน์โหลดเอกสาร</label>
 							<ul class=" dropdown-open z-20 menu p-2 shadow rounded-box w-52">
 								{#each filesDownloader as file}
 									<li>

--- a/src/routes/dashboard/parent-permission-submission/+page.svelte
+++ b/src/routes/dashboard/parent-permission-submission/+page.svelte
@@ -91,7 +91,7 @@
 			class:badge-success={isAlreadySubmit}
 			class="badge"
 		>
-			{isAlreadySubmit ? 'หลักฐานการชำระถูกส่งเรียบร้อย' : 'คุณยังไม่ได้ส่งหลักฐานการชำระ'}
+			{isAlreadySubmit ? 'หนังสือถูกส่งเรียบร้อย' : 'คุณยังไม่ได้ส่งหนังสือ'}
 		</span>
 		<p>
 			เนื่องจากการส่งหลักฐานการยืนยันจากผู้ปกครอง เป็นการยืนยันว่าคุณจะเข้าร่วมโครงการนี้
@@ -105,7 +105,9 @@
 			<form enctype="multipart/form-data" method="POST" use:enhance>
 				<div class="flex flex-col gap-6 items-center justify-center w-full">
 					<figure class="border-2 border-base-content/30 rounded-lg p-2">
-						<div class="divider"><span class="text-sm font-semibold">หมายเลขบัญชี</span></div>
+						<div class="divider">
+							<span class="text-sm font-semibold">หนังสือขออณุญาตผู้ปกครอง</span>
+						</div>
 						<a
 							target="_blank"
 							class="cursor-zoom-in"


### PR DESCRIPTION
This pull request fixes a misspelling in the text on the user dashboard

### Changes

* Update the spelling of "ส่งหลักฐานขออณุญาตผู้ปกครอง" to "ส่งหนังสือขออณุญาตผู้ปกครอง"
* Update the spelling of "ไฟล์ขออณุญาตผู้ปกครอง" to "หนังสือขออณุญาตผู้ปกครอง"
* Update the drop-down menu label and value from "นาง" to "นางสาว"
* Update the spelling of {isAlreadySubmit ? 'หลักฐานการชำระถูกส่งเรียบร้อย' : 'คุณยังไม่ได้ส่งหลักฐานการชำระ'} to {isAlreadySubmit ? 'หนังสือถูกส่งเรียบร้อย' : 'คุณยังไม่ได้ส่งหนังสือ'} in [src/routes/dashboard/parent-permission-submission/+page.svelte](https://github.com/textures1245/csmju-comcamp-22nd-promote/compare/prototype...moking55:prototype?expand=1#diff-7d8b5293b61b218451c487bb0db93d5bef028a412220159fc2d38f0fd4f4cc18)
Additional Notes:

This is a small change that should not have any other unintended consequences.

Please review and merge this pull request.