### PR TITLE
Hotfix: fix scrolling bug in main page

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,8 +1,8 @@
 const navbarMenu = [
 	{
 		label: 'เกี่ยวกับ',
-		yValue: 200,
-		ref: '#about-comcamp-section'
+		ref: '',
+		yValue: 0
 	},
 	{
 		label: 'หัวข้ออบรม',

--- a/src/lib/views/About.svelte
+++ b/src/lib/views/About.svelte
@@ -2,8 +2,8 @@
 	import { aboutComcamp } from '$lib/data';
 </script>
 
-<section class="my-16 z-10">
-	<div id="#about-comcamp-section" class="container mx-auto">
+<section id="#about-comcamp-section" class="my-16 z-10">
+	<div class="container mx-auto">
 		<article class="md:prose-lg mx-3 prose-sm">
 			<h1
 				data-aos="fade-right"


### PR DESCRIPTION
This pull request fixes a bug that was causing the scrolling to jump when the page loaded. The bug was caused by the #about-comcamp-section element being included in the ref array in data.ts. This pull request removes the #about-comcamp-section element from the ref array and sets the yValue to 0.

Changes:

data.ts:
- Removed the #about-comcamp-section element from the ref array
- Set the yValue to 0

This pull request has been tested manually and the scrolling bug has been fixed.